### PR TITLE
Add support for mailing lists

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -14,6 +14,11 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.Handle("/send/", alice.New().ThenFunc(SendMail)).Methods("POST")
+	router.Handle("/send/list/", alice.New().ThenFunc(SendMailList)).Methods("POST")
+	router.Handle("/list/create/", alice.New().ThenFunc(CreateMailList)).Methods("POST")
+	router.Handle("/list/add/", alice.New().ThenFunc(AddToMailList)).Methods("POST")
+	router.Handle("/list/remove/", alice.New().ThenFunc(RemoveFromMailList)).Methods("POST")
+	router.Handle("/list/{id}/", alice.New().ThenFunc(GetMailList)).Methods("GET")
 }
 
 /*
@@ -31,4 +36,102 @@ func SendMail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(mail_status)
+}
+
+/*
+	Endpoint to send mail to a specified mail list,
+	based on a specified template
+*/
+func SendMailList(w http.ResponseWriter, r *http.Request) {
+	var mail_order_list models.MailOrderList
+	json.NewDecoder(r.Body).Decode(&mail_order_list)
+
+	mail_status, err := service.SendMailByList(mail_order_list)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(mail_status)
+}
+
+/*
+	Endpoint to create a mailing list
+*/
+func CreateMailList(w http.ResponseWriter, r *http.Request) {
+	var mail_list models.MailList
+	json.NewDecoder(r.Body).Decode(&mail_list)
+
+	err := service.CreateMailList(mail_list)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	created_list, err := service.GetMailList(mail_list.ID)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(created_list)
+}
+
+/*
+	Endpoint to add to a mailing list
+*/
+func AddToMailList(w http.ResponseWriter, r *http.Request) {
+	var mail_list models.MailList
+	json.NewDecoder(r.Body).Decode(&mail_list)
+
+	err := service.AddToMailList(mail_list)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	modified_list, err := service.GetMailList(mail_list.ID)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(modified_list)
+}
+
+/*
+	Endpoint to remove from a mailing list
+*/
+func RemoveFromMailList(w http.ResponseWriter, r *http.Request) {
+	var mail_list models.MailList
+	json.NewDecoder(r.Body).Decode(&mail_list)
+
+	err := service.RemoveFromMailList(mail_list)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	modified_list, err := service.GetMailList(mail_list.ID)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(modified_list)
+}
+
+/*
+	Endpoint to get a mailing list by id
+*/
+func GetMailList(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	mail_list, err := service.GetMailList(id)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(mail_list)
 }

--- a/models/mail_list.go
+++ b/models/mail_list.go
@@ -1,6 +1,6 @@
 package models
 
 type MailList struct {
-	ListID  string   `json:"listId"`
+	ID      string   `json:"id"`
 	UserIDs []string `json:"userIds"`
 }

--- a/models/mail_list.go
+++ b/models/mail_list.go
@@ -1,0 +1,6 @@
+package models
+
+type MailList struct {
+	ListID  string   `json:"listId"`
+	UserIDs []string `json:"userIds"`
+}

--- a/models/mail_order_list.go
+++ b/models/mail_order_list.go
@@ -1,0 +1,6 @@
+package models
+
+type MailOrderList struct {
+	ListID   string `json:"listId"`
+	Template string `json:"template"`
+}

--- a/service/mail_service.go
+++ b/service/mail_service.go
@@ -111,3 +111,50 @@ func SendMail(mail_info models.MailInfo) (*models.MailStatus, error) {
 
 	return &mail_status, nil
 }
+
+/*
+	Create a mailing list with the given id and initial set of user, if provided
+*/
+func CreateMailList(mail_list models.MailList) error {
+	if mail_list.UserIDs == nil {
+		mail_list.UserIDs = []string{}
+	}
+
+	return db.Insert("lists", &mail_list)
+}
+
+/*
+	Adds the given users to the specified mailing list
+*/
+func AddToMailList(mail_list models.MailList) error {
+	selector := bson.M{
+		"id": mail_list.ListID,
+	}
+
+	modifier := bson.M{
+		"$addToSet": bson.M{
+			"userids": mail_list.UserIDs,
+		},
+	}
+
+	return db.Update("lists", selector, &modifier)
+}
+
+/*
+	Removes the given users from the specified mailing list
+*/
+func RemoveFromMailList(mail_list models.MailList) error {
+	selector := bson.M{
+		"id": mail_list.ListID,
+	}
+
+	modifier := bson.M{
+		"$pull": bson.M{
+			"userids": bson.M{
+				"$in": mail_list.UserIDs,
+			},
+		},
+	}
+
+	return db.Update("lists", selector, &modifier)
+}

--- a/service/mail_service.go
+++ b/service/mail_service.go
@@ -28,12 +28,7 @@ func init() {
 	Substitution will be generated based on user info
 */
 func SendMailByList(mail_order_list models.MailOrderList) (*models.MailStatus, error) {
-	query := bson.M{
-		"id": mail_order_list.ListID,
-	}
-
-	var mail_list models.MailList
-	err := db.FindOne("lists", query, &mail_list)
+	mail_list, err := GetMailList(mail_order_list.ListID)
 
 	if err != nil {
 		return nil, err
@@ -128,12 +123,14 @@ func CreateMailList(mail_list models.MailList) error {
 */
 func AddToMailList(mail_list models.MailList) error {
 	selector := bson.M{
-		"id": mail_list.ListID,
+		"id": mail_list.ID,
 	}
 
 	modifier := bson.M{
 		"$addToSet": bson.M{
-			"userids": mail_list.UserIDs,
+			"userids": bson.M{
+				"$each": mail_list.UserIDs,
+			},
 		},
 	}
 
@@ -145,7 +142,7 @@ func AddToMailList(mail_list models.MailList) error {
 */
 func RemoveFromMailList(mail_list models.MailList) error {
 	selector := bson.M{
-		"id": mail_list.ListID,
+		"id": mail_list.ID,
 	}
 
 	modifier := bson.M{
@@ -157,4 +154,22 @@ func RemoveFromMailList(mail_list models.MailList) error {
 	}
 
 	return db.Update("lists", selector, &modifier)
+}
+
+/*
+	Gets the mail list with the given id
+*/
+func GetMailList(id string) (*models.MailList, error) {
+	query := bson.M{
+		"id": id,
+	}
+
+	var mail_list models.MailList
+	err := db.FindOne("lists", query, &mail_list)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &mail_list, nil
 }

--- a/service/mail_service.go
+++ b/service/mail_service.go
@@ -4,10 +4,48 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/HackIllinois/api-commons/database"
 	"github.com/HackIllinois/api-mail/config"
 	"github.com/HackIllinois/api-mail/models"
+	"gopkg.in/mgo.v2/bson"
 	"net/http"
 )
+
+var db database.MongoDatabase
+
+func init() {
+	db_connection, err := database.InitMongoDatabase(config.MAIL_DB_HOST, config.MAIL_DB_NAME)
+
+	if err != nil {
+		panic(err)
+	}
+
+	db = db_connection
+}
+
+/*
+	Send mail to the users in the given mailing list, using the provided template
+	Substitution will be generated based on user info
+*/
+func SendMailByList(mail_order_list models.MailOrderList) (*models.MailStatus, error) {
+	query := bson.M{
+		"id": mail_order_list.ListID,
+	}
+
+	var mail_list models.MailList
+	err := db.FindOne("lists", query, &mail_list)
+
+	if err != nil {
+		return nil, err
+	}
+
+	mail_order := models.MailOrder{
+		IDs:      mail_list.UserIDs,
+		Template: mail_order_list.Template,
+	}
+
+	return SendMailByID(mail_order)
+}
 
 /*
 	Send mail the the users with the given ids, using the provided template

--- a/tests/mail_test.go
+++ b/tests/mail_test.go
@@ -1,11 +1,174 @@
 package tests
 
 import (
+	"github.com/HackIllinois/api-commons/database"
+	"github.com/HackIllinois/api-mail/config"
+	"github.com/HackIllinois/api-mail/models"
+	"github.com/HackIllinois/api-mail/service"
+	"reflect"
 	"testing"
 )
 
+var db database.MongoDatabase
+
+func init() {
+	db_connection, err := database.InitMongoDatabase(config.MAIL_DB_HOST, config.MAIL_DB_NAME)
+
+	if err != nil {
+		panic(err)
+	}
+
+	db = db_connection
+}
+
 /*
-	Placeholder test for travis build
+	Initialize databse with test user info
 */
-func TestPlaceholder(t *testing.T) {
+func SetupTestDB(t *testing.T) {
+	err := db.Insert("lists", &models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid1", "userid2"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Drop test db
+*/
+func CleanupTestDB(t *testing.T) {
+	session := db.GetSession()
+	defer session.Close()
+
+	err := session.DB(config.MAIL_DB_NAME).DropDatabase()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/*
+	Tests getting a mail list from the db at the service level
+*/
+func TestGetMailListService(t *testing.T) {
+	SetupTestDB(t)
+
+	mail_list, err := service.GetMailList("testlist")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid1", "userid2"},
+	}
+
+	if !reflect.DeepEqual(mail_list, expected) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected, mail_list)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests creating a mailing list
+*/
+func TestCreateMailListService(t *testing.T) {
+	SetupTestDB(t)
+
+	mail_list := models.MailList{
+		ID:      "testlist2",
+		UserIDs: []string{"userid1", "userid2"},
+	}
+
+	err := service.CreateMailList(mail_list)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retreived_list, err := service.GetMailList("testlist2")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(retreived_list, &mail_list) {
+		t.Errorf("Wrong user info. Expected %v, got %v", &mail_list, retreived_list)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests adding to a mailing list
+*/
+func TestAddToMailList(t *testing.T) {
+	SetupTestDB(t)
+
+	mail_list := models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid3", "userid4"},
+	}
+
+	err := service.AddToMailList(mail_list)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retreived_list, err := service.GetMailList("testlist")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid1", "userid2", "userid3", "userid4"},
+	}
+
+	if !reflect.DeepEqual(retreived_list, expected) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected, retreived_list)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Tests removing from a mailing list
+*/
+func TestRemoveFromMailList(t *testing.T) {
+	SetupTestDB(t)
+
+	mail_list := models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid2"},
+	}
+
+	err := service.RemoveFromMailList(mail_list)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retreived_list, err := service.GetMailList("testlist")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &models.MailList{
+		ID:      "testlist",
+		UserIDs: []string{"userid1"},
+	}
+
+	if !reflect.DeepEqual(retreived_list, expected) {
+		t.Errorf("Wrong user info. Expected %v, got %v", expected, retreived_list)
+	}
+
+	CleanupTestDB(t)
 }


### PR DESCRIPTION
Addresses #5 

- [x] Add support for mailing lists
    - [x] Create new mailing lists
    - [x] Add users to mailing list
    - [x] Remove users from mailing list
    - [x] Retrieve users in mailing list
- [x] Add endpoint for sending templated emails to a mailing list

All modifying database operations in this PR are atomic, since multiple users may trigger events which add their id to the same mailing list at the same time.