### PR TITLE
[WIP] Added FirstName and LastName, made relevant substitutions in emails

### DIFF
--- a/models/user_info.go
+++ b/models/user_info.go
@@ -1,7 +1,9 @@
 package models
 
 type UserInfo struct {
-	ID       string `json:"id"`
-	Username string `json:"username"`
-	Email    string `json:"email"`
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Email     string `json:"email"`
 }

--- a/service/mail_service.go
+++ b/service/mail_service.go
@@ -63,10 +63,10 @@ func SendMailByID(mail_order models.MailOrder) (*models.MailStatus, error) {
 
 		mail_info.Recipients[i].Address = models.Address{
 			Email: user_info.Email,
-			Name:  user_info.Username,
+			Name:  fmt.Sprintf("%s %s", user_info.FirstName, user_info.LastName),
 		}
 		mail_info.Recipients[i].Substitutions = models.Substitutions{
-			"name": user_info.Username,
+			"name": user_info.FirstName,
 		}
 	}
 

--- a/service/mail_service.go
+++ b/service/mail_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"bytes"
 	"encoding/json"
 	"errors"


### PR DESCRIPTION
- [x] Added a `FirstName` and `LastName` field to `UserInfo`
- [x] Get the user's first name from the user service and use it as the substitution for the "name" key, and the `Name` in the address field (please confirm if this is desired.)

Addresses #1 